### PR TITLE
Fix areAreas not finding overlap

### DIFF
--- a/src/main/java/ch/interlis/iox_j/validator/Validator.java
+++ b/src/main/java/ch/interlis/iox_j/validator/Validator.java
@@ -2165,48 +2165,45 @@ public class Validator implements ch.interlis.iox.IoxValidator {
                     //Value currentValue = getValueFromObjectPath(null, iomObj, pathToStructEle, null);
                     if (complexObjects.size()>0) {
                         //Collection<IomObject> complexObjects = currentValue.getComplexObjects();
-                        Iterator<IomObject> iterator = complexObjects.iterator();
-                        while (iterator.hasNext()) {
-                            IomObject currentObj=iterator.next();
-                            getStructElesFromAttrPath(pathToSurfaceAttr, currentObj.getobjectoid(),listOfPolygons, currentObj, 0);
-                        }                               
-                        for (IomObject polygon : listOfPolygons) {
-                            try {
-                                polygonPool.addPolygon(null, polygon.getobjectoid(), polygon, validationKind, errFact);
-                            } catch (IoxException e) {
-                                EhiLogger.logError(e);  
-                            }
+                        for (IomObject currentObj : complexObjects) {
+                            getStructElesFromAttrPath(pathToSurfaceAttr, currentObj.getobjectoid(), listOfPolygons, currentObj, 0);
                         }
-                        List<IoxInvalidDataException> intersections=polygonPool.validate();
-                        if(intersections!=null) {
-                            if(!disableAreAreasMessages && intersections.size()>0){
-                                for(IoxInvalidDataException ex:intersections){ // iterate through non-overlay intersections
-                                    String tid1=ex.getTid();
-                                    String iliqname=ex.getIliqname();
-                                    errFact.setTid(tid1);
-                                    errFact.setIliqname(iliqname);
-                                    if(ex instanceof IoxIntersectionException) {
-                                        logMsg(areaOverlapValidation, ((IoxIntersectionException) ex).getIntersection().toShortString());
-                                        EhiLogger.traceState(ex.toString());
-                                    }else {
-                                        logMsg(areaOverlapValidation, ex.getMessage());
-                                    }
-                                }
-                                setCurrentMainObj(null);
-                            }
-                            returnValue = returnValue && false;
-                            if(disableAreAreasMessages && !returnValue) {
-                                // short circuit; no need to further evaluate
-                                break;
-                            }
-                        }                   
                     }
                 }
             }
-            if(!returnValue) {
-                EhiLogger.traceState(mainObjTag+ ":" + currentFunction.getScopedName(null) + " returned false"); 
+
+            for (IomObject polygon : listOfPolygons) {
+                try {
+                    polygonPool.addPolygon(null, polygon.getobjectoid(), polygon, validationKind, errFact);
+                } catch (IoxException e) {
+                    EhiLogger.logError(e);
+                }
             }
-            return new Value(returnValue);
+
+            List<IoxInvalidDataException> intersections=polygonPool.validate();
+            if(intersections!=null) {
+                if(!disableAreAreasMessages && intersections.size()>0){
+                    for(IoxInvalidDataException ex:intersections){ // iterate through non-overlay intersections
+                        String tid1=ex.getTid();
+                        String iliqname=ex.getIliqname();
+                        errFact.setTid(tid1);
+                        errFact.setIliqname(iliqname);
+                        if(ex instanceof IoxIntersectionException) {
+                            logMsg(areaOverlapValidation, ((IoxIntersectionException) ex).getIntersection().toShortString());
+                            EhiLogger.traceState(ex.toString());
+                        }else {
+                            logMsg(areaOverlapValidation, ex.getMessage());
+                        }
+                    }
+                    setCurrentMainObj(null);
+                }
+
+                // short circuit; no need to further evaluate
+                EhiLogger.traceState(mainObjTag+ ":" + currentFunction.getScopedName(null) + " returned false");
+                return new Value(false);
+            }
+
+            return new Value(true);
 		}
 	}
 	

--- a/src/main/java/ch/interlis/iox_j/validator/Validator.java
+++ b/src/main/java/ch/interlis/iox_j/validator/Validator.java
@@ -2091,7 +2091,7 @@ public class Validator implements ch.interlis.iox.IoxValidator {
 		return new Value(counter);
 	}
 	
-	public Value evaluateAreArea(IomObject mainIomObj, Value value, PathEl[] pathToStructEle, PathEl[] pathToSurfaceAttr, Function currentFunction) {
+	public Value evaluateAreArea(IomObject mainIomObj, Value value, PathEl[] pathToStructEle, PathEl[] pathToSurfaceAttr, Function currentFunction, String validationKind) {
 		String mainObjTag=mainIomObj.getobjecttag();
 		if(pathToStructEle == null){
 			ItfAreaPolygon2Linetable polygonPool = new ItfAreaPolygon2Linetable(mainObjTag, objPoolManager); // create new pool of polygons
@@ -2115,7 +2115,7 @@ public class Validator implements ch.interlis.iox.IoxValidator {
 			}
             for (IomObject polygon : listOfPolygons) {
                 try {
-                    polygonPool.addLines(null, polygon.getobjectoid(), polygonPool.getLinesFromPolygon(polygon));
+                    polygonPool.addPolygon(null, polygon.getobjectoid(), polygon, validationKind, errFact);
                 } catch (IoxException e) {
                     EhiLogger.logError(e);  
                 }
@@ -2172,7 +2172,7 @@ public class Validator implements ch.interlis.iox.IoxValidator {
                         }                               
                         for (IomObject polygon : listOfPolygons) {
                             try {
-                                polygonPool.addLines(null, polygon.getobjectoid(), polygonPool.getLinesFromPolygon(polygon));
+                                polygonPool.addPolygon(null, polygon.getobjectoid(), polygon, validationKind, errFact);
                             } catch (IoxException e) {
                                 EhiLogger.logError(e);  
                             }

--- a/src/main/java/ch/interlis/iox_j/validator/functions/Interlis.java
+++ b/src/main/java/ch/interlis/iox_j/validator/functions/Interlis.java
@@ -308,7 +308,7 @@ public class Interlis {
                     return isArea;
                 }
             }
-            Value isArea = validator.evaluateAreArea(iomObj, argObjects, surfaceBagPath, surfaceAttrPath, currentFunction);
+            Value isArea = validator.evaluateAreArea(iomObj, argObjects, surfaceBagPath, surfaceAttrPath, currentFunction, validationKind);
             functions.put(currentFunction, isArea);
             return isArea;
         }

--- a/src/main/java/ch/interlis/iox_j/validator/functions/Interlis_ext.java
+++ b/src/main/java/ch/interlis/iox_j/validator/functions/Interlis_ext.java
@@ -124,7 +124,7 @@ public class Interlis_ext {
                     return isArea;
                 }
             }
-            Value isArea = validator.evaluateAreArea(iomObj, argObjects, surfaceBagPath, surfaceAttrPath, currentFunction);
+            Value isArea = validator.evaluateAreArea(iomObj, argObjects, surfaceBagPath, surfaceAttrPath, currentFunction, validationKind);
             functions.put(currentFunction, isArea);
             return isArea;
         }

--- a/src/test/java/ch/interlis/iox_j/validator/AreAreas23Test.java
+++ b/src/test/java/ch/interlis/iox_j/validator/AreAreas23Test.java
@@ -552,6 +552,74 @@ public class AreAreas23Test {
         assertEquals("Intersection coord1 (490000.000, 78000.000), tids o1/flaeche[1], o2/flaeche[1]",errs.get(1).trim());
         assertEquals("Set Constraint AreAreas23.Topic.ClassE.Constraint1 is not true.",errs.get(2));
     }
+
+    @Test
+    public void classE_allObjectE_TwoIdenticalObjects_Overlap_Fail() {
+        String x1 = "486000.000";
+        String y1 = "75000.000";
+        String x2 = "490000.000";
+        String y2 = "80000.000";
+
+        IomObject attrFlaeche = createRectangle(x1, y1, x2, y2);
+        Iom_jObject classE1 = new Iom_jObject(CLASSE, OID1);
+        classE1.setattrvalue("art", "a");
+        classE1.addattrobj("flaeche", attrFlaeche);
+
+        IomObject attrFlaeche2 = createRectangle(x1, y1, x2, y2); // equal to attrFlaeche
+        Iom_jObject classE2 = new Iom_jObject(CLASSE, OID2);
+        classE2.setattrvalue("art", "a");
+        classE2.addattrobj("flaeche", attrFlaeche2);
+
+        // Create and run validator.
+        ValidationConfig modelConfig = new ValidationConfig();
+        modelConfig.setConfigValue(ValidationConfig.PARAMETER, ValidationConfig.DISABLE_AREAREAS_MESSAGES, ValidationConfig.TRUE);
+        LogCollector logger = new LogCollector();
+        LogEventFactory errFactory = new LogEventFactory();
+        Settings settings = new Settings();
+        Validator validator = new Validator(td, modelConfig, logger, errFactory, settings);
+        validator.validate(new StartTransferEvent());
+        validator.validate(new StartBasketEvent(TOPIC, BID));
+        validator.validate(new ObjectEvent(classE1));
+        validator.validate(new ObjectEvent(classE2));
+        validator.validate(new EndBasketEvent());
+        validator.validate(new EndTransferEvent());
+        // Asserts.
+        assertEquals(1, logger.getErrs().size());
+        assertEquals("Set Constraint AreAreas23.Topic.ClassE.Constraint1 is not true.",
+                logger.getErrs().get(0).getEventMsg());
+    }
+
+    @Test
+    public void classE_allObjectE_ObjectWithinObject_Overlap_Fail() {
+        IomObject attrFlaeche = createRectangle("490000.000", "70000.000", "500000.000", "80000.000");
+        Iom_jObject classE1 = new Iom_jObject(CLASSE, OID1);
+        classE1.setattrvalue("art", "a");
+        classE1.addattrobj("flaeche", attrFlaeche);
+
+        IomObject attrFlaeche2 = createRectangle("492000.000", "72000.000", "498000.000", "78000.000"); // completely within attrFlaeche
+        Iom_jObject classE2 = new Iom_jObject(CLASSE, OID2);
+        classE2.setattrvalue("art", "a");
+        classE2.addattrobj("flaeche", attrFlaeche2);
+
+        // Create and run validator.
+        ValidationConfig modelConfig = new ValidationConfig();
+        modelConfig.setConfigValue(ValidationConfig.PARAMETER, ValidationConfig.DISABLE_AREAREAS_MESSAGES, ValidationConfig.TRUE);
+        LogCollector logger = new LogCollector();
+        LogEventFactory errFactory = new LogEventFactory();
+        Settings settings = new Settings();
+        Validator validator = new Validator(td, modelConfig, logger, errFactory, settings);
+        validator.validate(new StartTransferEvent());
+        validator.validate(new StartBasketEvent(TOPIC, BID));
+        validator.validate(new ObjectEvent(classE1));
+        validator.validate(new ObjectEvent(classE2));
+        validator.validate(new EndBasketEvent());
+        validator.validate(new EndTransferEvent());
+        // Asserts.
+        assertEquals(1, logger.getErrs().size());
+        assertEquals("Set Constraint AreAreas23.Topic.ClassE.Constraint1 is not true.",
+                logger.getErrs().get(0).getEventMsg());
+    }
+
     @Test
     public void classF_allObjectF_TwoObject_Overlap_Fail() {
 
@@ -561,6 +629,73 @@ public class AreAreas23Test {
         classF1.addattrobj("attr2", structA);
 
         IomObject structA2 = createStructA("488000.000", "75000.000", "494000.000", "80000.000"); // overlaps structA
+        Iom_jObject classF2 = new Iom_jObject(CLASSF, OID2);
+        classF2.setattrvalue("art", "a");
+        classF2.addattrobj("attr2", structA2);
+
+        // Create and run validator.
+        ValidationConfig modelConfig = new ValidationConfig();
+        modelConfig.setConfigValue(ValidationConfig.PARAMETER, ValidationConfig.DISABLE_AREAREAS_MESSAGES, ValidationConfig.TRUE);
+        LogCollector logger = new LogCollector();
+        LogEventFactory errFactory = new LogEventFactory();
+        Settings settings = new Settings();
+        Validator validator = new Validator(td, modelConfig, logger, errFactory, settings);
+        validator.validate(new StartTransferEvent());
+        validator.validate(new StartBasketEvent(TOPIC, BID));
+        validator.validate(new ObjectEvent(classF1));
+        validator.validate(new ObjectEvent(classF2));
+        validator.validate(new EndBasketEvent());
+        validator.validate(new EndTransferEvent());
+        // Asserts.
+        assertEquals(1, logger.getErrs().size());
+        assertEquals("Set Constraint AreAreas23.Topic.ClassF.Constraint1 is not true.",
+                logger.getErrs().get(0).getEventMsg());
+    }
+
+    @Test
+    public void classF_allObjectF_TwoIdenticalObjects_Overlap_Fail() {
+         String x1 = "486000.000";
+         String y1 = "75000.000";
+         String x2 = "490000.000";
+         String y2 = "80000.000";
+
+        IomObject structA = createStructA(x1, y1, x2, y2);
+        Iom_jObject classF1 = new Iom_jObject(CLASSF, OID1);
+        classF1.setattrvalue("art", "a");
+        classF1.addattrobj("attr2", structA);
+
+        IomObject structA2 = createStructA(x1, y1, x2, y2); // equal to structA
+        Iom_jObject classF2 = new Iom_jObject(CLASSF, OID2);
+        classF2.setattrvalue("art", "a");
+        classF2.addattrobj("attr2", structA2);
+
+        // Create and run validator.
+        ValidationConfig modelConfig = new ValidationConfig();
+        modelConfig.setConfigValue(ValidationConfig.PARAMETER, ValidationConfig.DISABLE_AREAREAS_MESSAGES, ValidationConfig.TRUE);
+        LogCollector logger = new LogCollector();
+        LogEventFactory errFactory = new LogEventFactory();
+        Settings settings = new Settings();
+        Validator validator = new Validator(td, modelConfig, logger, errFactory, settings);
+        validator.validate(new StartTransferEvent());
+        validator.validate(new StartBasketEvent(TOPIC, BID));
+        validator.validate(new ObjectEvent(classF1));
+        validator.validate(new ObjectEvent(classF2));
+        validator.validate(new EndBasketEvent());
+        validator.validate(new EndTransferEvent());
+        // Asserts.
+        assertEquals(1, logger.getErrs().size());
+        assertEquals("Set Constraint AreAreas23.Topic.ClassF.Constraint1 is not true.",
+                     logger.getErrs().get(0).getEventMsg());
+    }
+
+    @Test
+    public void classF_allObjectF_ObjectWithinObject_Overlap_Fail() {
+        IomObject structA = createStructA("490000.000", "70000.000", "500000.000", "80000.000");
+        Iom_jObject classF1 = new Iom_jObject(CLASSF, OID1);
+        classF1.setattrvalue("art", "a");
+        classF1.addattrobj("attr2", structA);
+
+        IomObject structA2 = createStructA("492000.000", "72000.000", "498000.000", "78000.000"); // completely within structA
         Iom_jObject classF2 = new Iom_jObject(CLASSF, OID2);
         classF2.setattrvalue("art", "a");
         classF2.addattrobj("attr2", structA2);

--- a/src/test/java/ch/interlis/iox_j/validator/AreAreas23Test.java
+++ b/src/test/java/ch/interlis/iox_j/validator/AreAreas23Test.java
@@ -139,7 +139,7 @@ public class AreAreas23Test {
     @Test
     public void classD2_perStructC_TwoObjectNoOverlap_Ok() {
 
-        Iom_jObject structA1_1 = createStructA("410000.000", "75000.000", "420000.000", "80000.000");
+        Iom_jObject structA1_1 = createStructA("480000.000", "75000.000", "482000.000", "80000.000");
 
         Iom_jObject structA1_2 = createStructA("483000.000", "75000.000", "486000.000", "80000.000");
 
@@ -150,7 +150,7 @@ public class AreAreas23Test {
         Iom_jObject structC1 = new Iom_jObject(STRUCTC, null);
         structC1.addattrobj("attr3", structB1);
 
-        Iom_jObject structA2 = createStructA("484000.000", "75000.000", "488000.000", "80000.000"); // overlaps structA1_2, but ok, because different structC
+        Iom_jObject structA2 = createStructA("488000.000", "75000.000", "490000.000", "80000.000");
 
         Iom_jObject structB2 = new Iom_jObject(STRUCTB, null);
         structB2.addattrobj("attr2", structA2);
@@ -158,7 +158,7 @@ public class AreAreas23Test {
         Iom_jObject structC2 = new Iom_jObject(STRUCTC, null);
         structC2.addattrobj("attr3", structB2);
 
-        Iom_jObject classD1 = new Iom_jObject(CLASSD2, OID2);
+        Iom_jObject classD1 = new Iom_jObject(CLASSD2, OID1);
         classD1.addattrobj("attr4", structC1);
         classD1.addattrobj("attr4", structC2);
 
@@ -176,12 +176,14 @@ public class AreAreas23Test {
 
         // Create and run validator.
         ValidationConfig modelConfig = new ValidationConfig();
+        modelConfig.setConfigValue(ValidationConfig.PARAMETER, ValidationConfig.DISABLE_AREAREAS_MESSAGES, ValidationConfig.TRUE);
         LogCollector logger = new LogCollector();
         LogEventFactory errFactory = new LogEventFactory();
         Settings settings = new Settings();
         Validator validator = new Validator(td, modelConfig, logger, errFactory, settings);
         validator.validate(new StartTransferEvent());
         validator.validate(new StartBasketEvent(TOPIC, BID));
+        validator.validate(new ObjectEvent(classD1));
         validator.validate(new ObjectEvent(classD2));
         validator.validate(new EndBasketEvent());
         validator.validate(new EndTransferEvent());


### PR DESCRIPTION
Fixes https://github.com/claeis/ilivalidator/issues/284

Die Evaluirung von [areAreas](https://github.com/claeis/iox-ili/blob/d3f191b05bc456dd73b6b578c27ce4ba77b4abd4/src/main/java/ch/interlis/iox_j/validator/Validator.java#L2094-L2211) hatte, wenn das SurfaceBag Argument (zweites Argument) nicht UNDEFINED war, jeweils für jede Geometrie, diese zu einer [_listOfPolygons_](https://github.com/GeoWerkstatt/iox-ili/blob/8caf9807e32e92d4228854b0dfae926322ce486e/src/main/java/ch/interlis/iox_j/validator/Validator.java#L2149) hinzugefügt und anschliessend die ganze _listOfPolygons_ zu einem [_polygonPool_](https://github.com/GeoWerkstatt/iox-ili/blob/8caf9807e32e92d4228854b0dfae926322ce486e/src/main/java/ch/interlis/iox_j/validator/Validator.java#L2148) [hinzugefügt](https://github.com/claeis/iox-ili/blob/d3f191b05bc456dd73b6b578c27ce4ba77b4abd4/src/main/java/ch/interlis/iox_j/validator/Validator.java#L2173-L2179). Da die _listOfPolygons_ und der _polygonPool_ zwischen den einzelnen Objekten nicht geleert wurden hatte dies zur Folge, dass dieselben Geometrien immer wieder mehrmals dem _polygonPool_ hinzugefügt wurden. Der _polygonPool_ wurde dann für [jedes Objekt einmal validiert](https://github.com/claeis/iox-ili/blob/d3f191b05bc456dd73b6b578c27ce4ba77b4abd4/src/main/java/ch/interlis/iox_j/validator/Validator.java#L2180). Vor dieser Änderung war das kein Problem, da sich identische Geometrien ebenfalls nicht überschnitten (!).

Neu werden auch wenn das _SurfaceBag_ Argument definiert ist, zuerst alle Geometrien aus den Objekten dem _polygonPool_ hinzugefügt und dann der _polygonPool_ einmal validiert.