### PR TITLE
Enable areAreas caching when argument "Objects" is "ALL"

### DIFF
--- a/src/main/java/ch/interlis/iox_j/validator/functions/Interlis.java
+++ b/src/main/java/ch/interlis/iox_j/validator/functions/Interlis.java
@@ -10,6 +10,7 @@ import ch.interlis.ili2c.metamodel.Evaluable;
 import ch.interlis.ili2c.metamodel.Function;
 import ch.interlis.ili2c.metamodel.FunctionCall;
 import ch.interlis.ili2c.metamodel.ObjectPath;
+import ch.interlis.ili2c.metamodel.Objects;
 import ch.interlis.ili2c.metamodel.PathEl;
 import ch.interlis.ili2c.metamodel.RoleDef;
 import ch.interlis.ili2c.metamodel.TextType;
@@ -300,6 +301,11 @@ public class Interlis {
                 }
             } catch (Ili2cException e) {
                 EhiLogger.logError(e);
+            }
+
+            // use cached value if it exists and first argument (Objects) is 'ALL'
+            if (functions.containsKey(functionCall) && arguments[0] instanceof Objects) {
+                return functions.get(functionCall);
             }
 
             Value isArea = validator.evaluateAreArea(iomObj, argObjects, surfaceBagPath, surfaceAttrPath, currentFunction, validationKind);

--- a/src/main/java/ch/interlis/iox_j/validator/functions/Interlis_ext.java
+++ b/src/main/java/ch/interlis/iox_j/validator/functions/Interlis_ext.java
@@ -9,6 +9,7 @@ import ch.interlis.ili2c.metamodel.Evaluable;
 import ch.interlis.ili2c.metamodel.Function;
 import ch.interlis.ili2c.metamodel.FunctionCall;
 import ch.interlis.ili2c.metamodel.ObjectPath;
+import ch.interlis.ili2c.metamodel.Objects;
 import ch.interlis.ili2c.metamodel.PathEl;
 import ch.interlis.ili2c.metamodel.RoleDef;
 import ch.interlis.ili2c.metamodel.TransferDescription;
@@ -117,6 +118,11 @@ public class Interlis_ext {
             } catch (Ili2cException e) {
                 EhiLogger.logError(e);
             }                    
+
+            // use cached value if it exists and first argument (Objects) is 'ALL'
+            if (functions.containsKey(functionCall) && arguments[0] instanceof Objects) {
+                return functions.get(functionCall);
+            }
 
             Value isArea = validator.evaluateAreArea(iomObj, argObjects, surfaceBagPath, surfaceAttrPath, currentFunction, validationKind);
             functions.put(functionCall, isArea);

--- a/src/test/java/ch/interlis/iox_j/validator/AreAreas23Test.java
+++ b/src/test/java/ch/interlis/iox_j/validator/AreAreas23Test.java
@@ -444,6 +444,58 @@ public class AreAreas23Test {
     }
 
     @Test
+    public void classD2_perStructC_TwoObject_OneStructValid_OneStructOverlap_Fail() {
+
+        // valid object
+        Iom_jObject structA1 = createStructA("500000.000", "75000.000", "510000.000", "80000.000");
+
+        Iom_jObject structB1 = new Iom_jObject(STRUCTB, null);
+        structB1.addattrobj("attr2", structA1);
+
+        Iom_jObject structC1 = new Iom_jObject(STRUCTC, null);
+        structC1.addattrobj("attr3", structB1);
+
+        Iom_jObject classD1 = new Iom_jObject(CLASSD2, OID1);
+        classD1.addattrobj("attr4", structC1);
+
+        // object with overlap
+        Iom_jObject structA2_1 = createStructA("486000.000", "75000.000", "490000.000", "80000.000");
+
+        Iom_jObject structA2_2 = createStructA("488000.000", "75000.000", "494000.000", "80000.000"); // overlaps structA2_1
+
+        Iom_jObject structB2_1 = new Iom_jObject(STRUCTB, null);
+        structB2_1.addattrobj("attr2", structA2_1);
+
+        Iom_jObject structB2_2 = new Iom_jObject(STRUCTB, null);
+        structB2_2.addattrobj("attr2", structA2_2);
+
+        Iom_jObject structC2 = new Iom_jObject(STRUCTC, null);
+        structC2.addattrobj("attr3", structB2_1);
+        structC2.addattrobj("attr3", structB2_2);
+
+        Iom_jObject classD2 = new Iom_jObject(CLASSD2, OID2);
+        classD2.addattrobj("attr4", structC2);
+
+        // Create and run validator.
+        ValidationConfig modelConfig = new ValidationConfig();
+        modelConfig.setConfigValue(ValidationConfig.PARAMETER, ValidationConfig.DISABLE_AREAREAS_MESSAGES, ValidationConfig.TRUE);
+        LogCollector logger = new LogCollector();
+        LogEventFactory errFactory = new LogEventFactory();
+        Settings settings = new Settings();
+        Validator validator = new Validator(td, modelConfig, logger, errFactory, settings);
+        validator.validate(new StartTransferEvent());
+        validator.validate(new StartBasketEvent(TOPIC, BID));
+        validator.validate(new ObjectEvent(classD1));
+        validator.validate(new ObjectEvent(classD2));
+        validator.validate(new EndBasketEvent());
+        validator.validate(new EndTransferEvent());
+        // Asserts.
+        assertEquals(1, logger.getErrs().size());
+        assertEquals("Mandatory Constraint AreAreas23.Topic.ClassD2.Constraint1 is not true.",
+                logger.getErrs().get(0).getEventMsg());
+    }
+
+    @Test
     public void classD3_allObjectD3_TwoObject_Overlap_Fail() {
 
         Iom_jObject structA = createStructA("486000.000", "75000.000", "490000.000", "80000.000");

--- a/src/test/java/ch/interlis/iox_j/validator/AreAreas23Test.java
+++ b/src/test/java/ch/interlis/iox_j/validator/AreAreas23Test.java
@@ -519,7 +519,6 @@ public class AreAreas23Test {
                 logger.getErrs().get(0).getEventMsg());
     }
     @Test
-    @Ignore("requires #107")
     public void classE_allObjectE_TwoObject_Overlap_DetailMsgs_Fail() {
 
         IomObject structA = createRectangle("486000.000", "75000.000", "490000.000", "80000.000");

--- a/src/test/java/ch/interlis/iox_j/validator/Function23Test.java
+++ b/src/test/java/ch/interlis/iox_j/validator/Function23Test.java
@@ -1926,7 +1926,6 @@ public class Function23Test {
 
 	// Es wird getestet ob die areAreas Funktion bei vielen Objekten genug schnell berechnet wird.
 	@Test
-	@Ignore("requires #107")
 	public void areAreas_Caching_Performance() {
 		// create test objects that satisfy the areAreas constraint
 		Iom_jObject[] testObjects = new Iom_jObject[10000];
@@ -1971,7 +1970,6 @@ public class Function23Test {
 
 	// Es wird getestet ob AREA bei vielen Objekten genug schnell berechnet wird.
 	@Test
-    @Ignore("requires #107")
 	public void area_Performance() {
 		// create test objects that satisfy the areAreas constraint
 		Iom_jObject[] testObjects = new Iom_jObject[10000];


### PR DESCRIPTION
relates to https://github.com/claeis/iox-ili/issues/107

Also adds a test that fails, when areAreas with first argument of "THIS" is cached incorrectly. Similar to testcase in https://github.com/claeis/ilivalidator/issues/338.