### PR TITLE
Improve CompoundCurveNoder performance

### DIFF
--- a/jtsext/src/main/java/ch/interlis/iom_j/itf/impl/jtsext/noding/CompoundCurveNoder.java
+++ b/jtsext/src/main/java/ch/interlis/iom_j/itf/impl/jtsext/noding/CompoundCurveNoder.java
@@ -135,23 +135,33 @@ private void computeIntersects(int ss0Idx,CompoundCurve ss0, int ss1Idx,Compound
     endPts1[1]=ss0.getEndPoint().getCoordinate();
     endPts2[0]=ss1.getStartPoint().getCoordinate();
     endPts2[1]=ss1.getEndPoint().getCoordinate();
-    if(ss0==ss1){
-    	// diese optimierung bringt
-        // 149188 ms
-        // 106694 ms
-        for (int i0 = 0; i0 < ss0.getNumSegments(); i0++) {
-            for (int i1 = i0+1; i1 < ss1.getNumSegments(); i1++) {
-              checkInteriorIntersections(ss0Idx,ss0, i0, ss1Idx,ss1, i1,endPts1,endPts2);
-            }
-          }
-    }else{
-        for (int i0 = 0; i0 < ss0.getNumSegments(); i0++) {
-            for (int i1 = 0; i1 < ss1.getNumSegments(); i1++) {
-              checkInteriorIntersections(ss0Idx,ss0, i0, ss1Idx,ss1, i1,endPts1,endPts2);
-            }
-          }
-    }
 	
+	STRtree index0 = new STRtree();
+	for (int i = 0; i < ss0.getNumSegments(); i++) {
+		CurveSegment seg = ss0.getSegments().get(i);
+		index0.insert(seg.computeEnvelopeInternal(), i);
+	}
+	if (ss0 == ss1) {
+		for (int i = 0; i < ss1.getNumSegments(); i++) {
+			CurveSegment seg = ss1.getSegments().get(i);
+			List<Integer> hits = index0.query(seg.computeEnvelopeInternal());
+			Collections.sort(hits); // Necessary because segIntAdd might lose intersections if they are not added in order
+			for (int hit : hits) {
+				if (hit > i) {
+					checkInteriorIntersections(ss0Idx,ss0, hit, ss1Idx,ss1, i,endPts1,endPts2);
+				}
+			}
+		}
+	} else {
+		for (int i = 0; i < ss1.getNumSegments(); i++) {
+			CurveSegment seg = ss1.getSegments().get(i);
+			List<Integer> hits = index0.query(seg.computeEnvelopeInternal());
+			Collections.sort(hits); // Necessary because segIntAdd might lose intersections if they are not added in order
+			for (int hit : hits) {
+				checkInteriorIntersections(ss0Idx,ss0, hit, ss1Idx,ss1, i,endPts1,endPts2);
+			}
+		}
+	}
 }
 	private void checkInteriorIntersections(int e0_i,CompoundCurve e0, int segIndex0, int e1_i,CompoundCurve e1, int segIndex1,Coordinate endPts1[],Coordinate endPts2[])
 	{


### PR DESCRIPTION
Using an Index to get the potentially intersecting segments in CompoundCurveNoder improves performance significantly. The validation time of the test XTF was reduced from 03m:42s.0117ms to 01m:59s.0314ms.

Attached Transfer and logs of runs with ilivalidator 1.14.1 and this version:
[CompoundCurveNoderIndexTest.zip](https://github.com/claeis/iox-ili/files/14311744/CompoundCurveNoderIndexTest.zip)
