### PR TITLE
Add coalesce function for numeric values

### DIFF
--- a/src/main/java/ch/interlis/iox_j/validator/functions/ObjectPoolFunctions.java
+++ b/src/main/java/ch/interlis/iox_j/validator/functions/ObjectPoolFunctions.java
@@ -47,7 +47,7 @@ public class ObjectPoolFunctions {
 
         if (currentFunction.getName().equals("allObjects")) {
             return evaluateAllObjects(validationKind, usageScope, iomObj, actualArguments);
-        } else if (currentFunction.getName().equals("coalesceNumeric")) {
+        } else if (currentFunction.getName().equals("coalesceN")) {
             return evaluateCoalesce(validationKind, usageScope, iomObj, actualArguments);
         } else {
             return Value.createNotYetImplemented();

--- a/src/test/data/validator/ObjectPool.ili
+++ b/src/test/data/validator/ObjectPool.ili
@@ -16,6 +16,6 @@ TYPE MODEL ObjectPool (en)
      * defaultValue: The value to return if mainValue is UNDEFINED.
      * Since 2025-06-25
      */
-     FUNCTION coalesceNumeric(inputValue: NUMERIC; defaultValue: NUMERIC): NUMERIC;
+     FUNCTION coalesceN(inputValue: NUMERIC; defaultValue: NUMERIC): NUMERIC;
 
 END ObjectPool.

--- a/src/test/data/validator/ObjectPool24_Test.ili
+++ b/src/test/data/validator/ObjectPool24_Test.ili
@@ -31,7 +31,7 @@ MODEL ObjectPool24_Test (en)
             DefaultValue: 0..100;
             Expected: 0..100;
 
-            MANDATORY CONSTRAINT coalesceNumericTest: ObjectPool.coalesceNumeric(InputValue, DefaultValue) == Expected;
+            MANDATORY CONSTRAINT coalesceNumericTest: ObjectPool.coalesceN(InputValue, DefaultValue) == Expected;
         END CoalesceTest;
     END Topic;
 

--- a/src/test/java/ch/interlis/iox_j/validator/ObjectPool24Test.java
+++ b/src/test/java/ch/interlis/iox_j/validator/ObjectPool24Test.java
@@ -95,7 +95,7 @@ public class ObjectPool24Test {
     }
 
     @Test
-    public void coalesceNumeric() {
+    public void coalesceN() {
         String[][] testCases = {
                 { "Input is defined", "42", "7", "42" },
                 { "Input UNDEFINED", null, "7", "7" },
@@ -112,15 +112,15 @@ public class ObjectPool24Test {
 
             LogCollector logger = ValidatorTestHelper.validateObjects(td, TOPIC, iomObj);
 
-            assertEquals("Test case: " + testCase[0] + " (coalesceNumeric(" + testCase[1] + ", " + testCase[2] + ") = " + testCase[3] + ")", 0, logger.getErrs().size());
+            assertEquals("Test case: " + testCase[0] + " (coalesceN(" + testCase[1] + ", " + testCase[2] + ") = " + testCase[3] + ")", 0, logger.getErrs().size());
         }
     }
 
     /**
-     * Test case that ensures that the coalesceNumeric is actually executed and can fail.
+     * Test case that ensures that coalesceN (coalesceNumeric) is actually executed and can fail.
      */
     @Test
-    public void coalesceNumericFail() {
+    public void coalesceNFail() {
         Iom_jObject iomObj = new Iom_jObject(CLASS_COALESCE_NUMERIC_TEST, "o1");
         iomObj.setattrvalue("InputValue", "42");
         iomObj.setattrvalue("DefaultValue", "7");


### PR DESCRIPTION
Der Funktionsaufruf `Math_V2.Sum(UNDEFINED)` gibt UNDEFINED zürick. Um damit weiterzurechnen braucht es eine Funktion, die UNDEFINED in einen default Wert umwandelt.
Siehe auch: https://github.com/claeis/iox-ili/pull/137#discussion_r2149924297